### PR TITLE
client{,_test}: allow base URL path to be specified and prepended to …

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"path"
 )
 
 // A Client is a NetBox client.  It can be used to retrieve network and
@@ -69,6 +70,16 @@ func (c *Client) newRequest(method string, endpoint string, options valuer) (*ht
 	if err != nil {
 		return nil, err
 	}
+
+	// Allow specifying a base path for API requests, so if a NetBox server
+	// resides at a path like http://example.com/netbox/, API requests will
+	// be sent to http://example.com/netbox/api/...
+	//
+	// Enables support of: https://github.com/digitalocean/netbox/issues/212.
+	if c.u.Path != "" {
+		rel.Path = path.Join(c.u.Path, rel.Path)
+	}
+
 	u := c.u.ResolveReference(rel)
 
 	// If no valuer specified, create a request with no query parameters

--- a/client_test.go
+++ b/client_test.go
@@ -80,6 +80,28 @@ func TestClientQueryParameters(t *testing.T) {
 	}
 }
 
+func TestClientPrependBaseURLPath(t *testing.T) {
+	u, err := url.Parse("http://example.com/netbox/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c := &Client{
+		u:      u,
+		client: &http.Client{},
+	}
+
+	req, err := c.newRequest(http.MethodGet, "/api/ipam/vlans", nil)
+	if err != nil {
+		t.Fatal("expected an error, but no error returned")
+	}
+
+	if want, got := "/netbox/api/ipam/vlans", req.URL.Path; want != got {
+		t.Fatalf("unexpected URL path:\n- want: %q\n-  got: %q",
+			want, got)
+	}
+}
+
 type testValuer struct {
 	Foo string
 	Bar int


### PR DESCRIPTION
…requests