### PR TITLE
netbox: export Valuer and Client HTTP request methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 netbox [![GoDoc](http://godoc.org/github.com/digitalocean/go-netbox?status.svg)](http://godoc.org/github.com/digitalocean/go-netbox) [![Build Status](https://travis-ci.org/digitalocean/go-netbox.svg?branch=master)](https://travis-ci.org/digitalocean/go-netbox) [![Report Card](https://goreportcard.com/badge/github.com/digitalocean/go-netbox)](https://goreportcard.com/report/github.com/digitalocean/go-netbox)
 ======
 
+**Note**: the existing code is "frozen" and will be updated when NetBox API
+2.0 is released.
+
 Package `netbox` provides an API client for [DigitalOcean's NetBox](https://github.com/digitalocean/netbox)
 IPAM and DCIM service.

--- a/client.go
+++ b/client.go
@@ -60,12 +60,12 @@ func NewClient(addr string, client *http.Client) (*Client, error) {
 	return c, nil
 }
 
-// newRequest creates a HTTP request using the input HTTP method, URL
-// endpoint, and a valuer which creates URL parameters for the request.
+// NewRequest creates a HTTP request using the input HTTP method, URL
+// endpoint, and a Valuer which creates URL parameters for the request.
 //
-// If a nil valuer is specified, no query parameters will be sent with the
+// If a nil Valuer is specified, no query parameters will be sent with the
 // request.
-func (c *Client) newRequest(method string, endpoint string, options valuer) (*http.Request, error) {
+func (c *Client) NewRequest(method string, endpoint string, options Valuer) (*http.Request, error) {
 	rel, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
@@ -96,8 +96,9 @@ func (c *Client) newRequest(method string, endpoint string, options valuer) (*ht
 	return http.NewRequest(method, u.String(), nil)
 }
 
-// do executes an HTTP request and unmarshals result JSON onto v.
-func (c *Client) do(req *http.Request, v interface{}) error {
+// Do executes an HTTP request and if v is not nil, Do unmarshals result
+// JSON onto v.
+func (c *Client) Do(req *http.Request, v interface{}) error {
 	res, err := c.client.Do(req)
 	if err != nil {
 		return err

--- a/client_test.go
+++ b/client_test.go
@@ -32,7 +32,7 @@ func TestClientBadJSON(t *testing.T) {
 	})
 	defer done()
 
-	req, err := c.newRequest(http.MethodGet, "/", nil)
+	req, err := c.NewRequest(http.MethodGet, "/", nil)
 	if err != nil {
 		t.Fatal("expected an error, but no error returned")
 	}
@@ -40,7 +40,7 @@ func TestClientBadJSON(t *testing.T) {
 	// Pass empty struct to trigger JSON unmarshaling path
 	var v struct{}
 
-	err = c.do(req, &v)
+	err = c.Do(req, &v)
 	if _, ok := err.(*json.SyntaxError); !ok {
 		t.Fatalf("unexpected error type: %T", err)
 	}
@@ -57,7 +57,7 @@ func TestClientQueryParameters(t *testing.T) {
 		wantBar = 1
 	)
 
-	req, err := c.newRequest(http.MethodGet, "/", testValuer{
+	req, err := c.NewRequest(http.MethodGet, "/", testValuer{
 		Foo: wantFoo,
 		Bar: wantBar,
 	})
@@ -91,7 +91,7 @@ func TestClientPrependBaseURLPath(t *testing.T) {
 		client: &http.Client{},
 	}
 
-	req, err := c.newRequest(http.MethodGet, "/api/ipam/vlans", nil)
+	req, err := c.NewRequest(http.MethodGet, "/api/ipam/vlans", nil)
 	if err != nil {
 		t.Fatal("expected an error, but no error returned")
 	}

--- a/dcim_related-connections.go
+++ b/dcim_related-connections.go
@@ -47,7 +47,7 @@ type PowerPortIdentifier struct {
 func (s *DCIMService) GetRelatedConnections(
 	peerDevice, peerInterface string,
 ) (*RelatedConnection, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		"/api/dcim/related-connections/",
 		&relatedConnectionsOptions{
@@ -60,7 +60,7 @@ func (s *DCIMService) GetRelatedConnections(
 	}
 
 	rc := new(RelatedConnection)
-	err = s.c.do(req, rc)
+	err = s.c.Do(req, rc)
 	if err != nil {
 		return nil, err
 	}

--- a/dcim_sites.go
+++ b/dcim_sites.go
@@ -47,7 +47,7 @@ type SiteIdentifier struct {
 
 // GetSite retrieves a Site object from NetBox by its ID.
 func (s *DCIMService) GetSite(id int) (*Site, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("/api/dcim/sites/%d", id),
 		nil,
@@ -57,18 +57,18 @@ func (s *DCIMService) GetSite(id int) (*Site, error) {
 	}
 
 	st := new(Site)
-	err = s.c.do(req, st)
+	err = s.c.Do(req, st)
 	return st, err
 }
 
 // ListSites retrives a list of Site objects from NetBox.
 func (s *DCIMService) ListSites() ([]*Site, error) {
-	req, err := s.c.newRequest(http.MethodGet, "/api/dcim/sites/", nil)
+	req, err := s.c.NewRequest(http.MethodGet, "/api/dcim/sites/", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var sts []*Site
-	err = s.c.do(req, &sts)
+	err = s.c.Do(req, &sts)
 	return sts, err
 }

--- a/ipam_aggregates.go
+++ b/ipam_aggregates.go
@@ -36,7 +36,7 @@ type Aggregate struct {
 
 // GetAggregate retrieves an Aggregate object from NetBox by its ID.
 func (s *IPAMService) GetAggregate(id int) (*Aggregate, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("/api/ipam/aggregates/%d", id),
 		nil,
@@ -46,7 +46,7 @@ func (s *IPAMService) GetAggregate(id int) (*Aggregate, error) {
 	}
 
 	a := new(Aggregate)
-	err = s.c.do(req, a)
+	err = s.c.Do(req, a)
 	return a, err
 }
 
@@ -55,13 +55,13 @@ func (s *IPAMService) GetAggregate(id int) (*Aggregate, error) {
 //
 // If options is nil, all Aggregates will be retrieved.
 func (s *IPAMService) ListAggregates(options *ListAggregatesOptions) ([]*Aggregate, error) {
-	req, err := s.c.newRequest(http.MethodGet, "/api/ipam/aggregates/", options)
+	req, err := s.c.NewRequest(http.MethodGet, "/api/ipam/aggregates/", options)
 	if err != nil {
 		return nil, err
 	}
 
 	var as []*Aggregate
-	err = s.c.do(req, &as)
+	err = s.c.Do(req, &as)
 	return as, err
 }
 

--- a/ipam_ipaddresses.go
+++ b/ipam_ipaddresses.go
@@ -46,7 +46,7 @@ type IPAddressIdentifier struct {
 
 // GetIPAddress retrieves an IPAddress object from NetBox by its ID.
 func (s *IPAMService) GetIPAddress(id int) (*IPAddress, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("/api/ipam/ip-addresses/%d", id),
 		nil,
@@ -56,7 +56,7 @@ func (s *IPAMService) GetIPAddress(id int) (*IPAddress, error) {
 	}
 
 	ip := new(IPAddress)
-	err = s.c.do(req, ip)
+	err = s.c.Do(req, ip)
 	return ip, err
 }
 
@@ -65,13 +65,13 @@ func (s *IPAMService) GetIPAddress(id int) (*IPAddress, error) {
 //
 // If options is nil, all IPAddresses will be retrieved.
 func (s *IPAMService) ListIPAddresses(options *ListIPAddressesOptions) ([]*IPAddress, error) {
-	req, err := s.c.newRequest(http.MethodGet, "/api/ipam/ip-addresses/", options)
+	req, err := s.c.NewRequest(http.MethodGet, "/api/ipam/ip-addresses/", options)
 	if err != nil {
 		return nil, err
 	}
 
 	var ips []*IPAddress
-	err = s.c.do(req, &ips)
+	err = s.c.Do(req, &ips)
 	return ips, err
 }
 

--- a/ipam_prefixes.go
+++ b/ipam_prefixes.go
@@ -38,7 +38,7 @@ type Prefix struct {
 
 // GetPrefix retrieves a Prefix object from NetBox by its ID.
 func (s *IPAMService) GetPrefix(id int) (*Prefix, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("/api/ipam/prefixes/%d", id),
 		nil,
@@ -48,7 +48,7 @@ func (s *IPAMService) GetPrefix(id int) (*Prefix, error) {
 	}
 
 	p := new(Prefix)
-	err = s.c.do(req, p)
+	err = s.c.Do(req, p)
 	return p, err
 }
 
@@ -57,13 +57,13 @@ func (s *IPAMService) GetPrefix(id int) (*Prefix, error) {
 //
 // If options is nil, all Prefixes will be retrieved.
 func (s *IPAMService) ListPrefixes(options *ListPrefixesOptions) ([]*Prefix, error) {
-	req, err := s.c.newRequest(http.MethodGet, "/api/ipam/prefixes/", options)
+	req, err := s.c.NewRequest(http.MethodGet, "/api/ipam/prefixes/", options)
 	if err != nil {
 		return nil, err
 	}
 
 	var ps []*Prefix
-	err = s.c.do(req, &ps)
+	err = s.c.Do(req, &ps)
 	return ps, err
 }
 

--- a/ipam_rirs.go
+++ b/ipam_rirs.go
@@ -39,7 +39,7 @@ type RIRIdentifier struct {
 
 // GetRIR retrieves an RIR object from NetBox by its ID.
 func (s *IPAMService) GetRIR(id int) (*RIR, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("/api/ipam/rirs/%d", id),
 		nil,
@@ -49,18 +49,18 @@ func (s *IPAMService) GetRIR(id int) (*RIR, error) {
 	}
 
 	r := new(RIR)
-	err = s.c.do(req, r)
+	err = s.c.Do(req, r)
 	return r, err
 }
 
 // ListRIRs retrives a list of RIR objects from NetBox.
 func (s *IPAMService) ListRIRs() ([]*RIR, error) {
-	req, err := s.c.newRequest(http.MethodGet, "/api/ipam/rirs/", nil)
+	req, err := s.c.NewRequest(http.MethodGet, "/api/ipam/rirs/", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var rs []*RIR
-	err = s.c.do(req, &rs)
+	err = s.c.Do(req, &rs)
 	return rs, err
 }

--- a/ipam_roles.go
+++ b/ipam_roles.go
@@ -40,7 +40,7 @@ type RoleIdentifier struct {
 
 // GetRole retrieves a Role object from NetBox by its ID.
 func (s *IPAMService) GetRole(id int) (*Role, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("/api/ipam/roles/%d", id),
 		nil,
@@ -50,18 +50,18 @@ func (s *IPAMService) GetRole(id int) (*Role, error) {
 	}
 
 	r := new(Role)
-	err = s.c.do(req, r)
+	err = s.c.Do(req, r)
 	return r, err
 }
 
 // ListRoles retrieves a list of Role objects from NetBox.
 func (s *IPAMService) ListRoles() ([]*Role, error) {
-	req, err := s.c.newRequest(http.MethodGet, "/api/ipam/roles/", nil)
+	req, err := s.c.NewRequest(http.MethodGet, "/api/ipam/roles/", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var rs []*Role
-	err = s.c.do(req, &rs)
+	err = s.c.Do(req, &rs)
 	return rs, err
 }

--- a/ipam_vlans.go
+++ b/ipam_vlans.go
@@ -54,7 +54,7 @@ type VLANIdentifier struct {
 
 // GetVLAN retrieves a VLAN object from NetBox by its ID.
 func (s *IPAMService) GetVLAN(id int) (*VLAN, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("/api/ipam/vlans/%d", id),
 		nil,
@@ -64,7 +64,7 @@ func (s *IPAMService) GetVLAN(id int) (*VLAN, error) {
 	}
 
 	vlan := new(VLAN)
-	err = s.c.do(req, vlan)
+	err = s.c.Do(req, vlan)
 	return vlan, err
 }
 
@@ -73,13 +73,13 @@ func (s *IPAMService) GetVLAN(id int) (*VLAN, error) {
 //
 // If options is nil, all VLANs will be retrieved.
 func (s *IPAMService) ListVLANs(options *ListVLANsOptions) ([]*VLAN, error) {
-	req, err := s.c.newRequest(http.MethodGet, "/api/ipam/vlans/", options)
+	req, err := s.c.NewRequest(http.MethodGet, "/api/ipam/vlans/", options)
 	if err != nil {
 		return nil, err
 	}
 
 	var vlans []*VLAN
-	err = s.c.do(req, &vlans)
+	err = s.c.Do(req, &vlans)
 	return vlans, err
 }
 

--- a/ipam_vrfs.go
+++ b/ipam_vrfs.go
@@ -38,7 +38,7 @@ type VRFIdentifier struct {
 
 // GetVRF retrieves a VRF object from NetBox by its ID.
 func (s *IPAMService) GetVRF(id int) (*VRF, error) {
-	req, err := s.c.newRequest(
+	req, err := s.c.NewRequest(
 		http.MethodGet,
 		fmt.Sprintf("/api/ipam/vrfs/%d", id),
 		nil,
@@ -48,18 +48,18 @@ func (s *IPAMService) GetVRF(id int) (*VRF, error) {
 	}
 
 	v := new(VRF)
-	err = s.c.do(req, v)
+	err = s.c.Do(req, v)
 	return v, err
 }
 
 // ListVRFs retrives a list of VRF objects from NetBox.
 func (s *IPAMService) ListVRFs() ([]*VRF, error) {
-	req, err := s.c.newRequest(http.MethodGet, "/api/ipam/vrfs/", nil)
+	req, err := s.c.NewRequest(http.MethodGet, "/api/ipam/vrfs/", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var vs []*VRF
-	err = s.c.do(req, &vs)
+	err = s.c.Do(req, &vs)
 	return vs, err
 }

--- a/netbox.go
+++ b/netbox.go
@@ -18,10 +18,10 @@ package netbox
 
 import "net/url"
 
-// A valuer is an object which can generate a url.Values map from itself.
-// valuer implementations are used to generate request URL parameters
+// A Valuer is an object which can generate a url.Values map from itself.
+// Valuer implementations are used to generate request URL parameters
 // that NetBox can use to filter data.
-type valuer interface {
+type Valuer interface {
 	values() (url.Values, error)
 }
 


### PR DESCRIPTION
Allow users outside of this package to make calls directly using the `Client` for unsupported endpoints, until API 2.0 is available.

/cc @andrewrynhard