### PR TITLE
netbox: export Valuer.Values

### DIFF
--- a/client.go
+++ b/client.go
@@ -87,7 +87,7 @@ func (c *Client) NewRequest(method string, endpoint string, options Valuer) (*ht
 		return http.NewRequest(method, u.String(), nil)
 	}
 
-	values, err := options.values()
+	values, err := options.Values()
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -107,7 +107,7 @@ type testValuer struct {
 	Bar int
 }
 
-func (q testValuer) values() (url.Values, error) {
+func (q testValuer) Values() (url.Values, error) {
 	v := url.Values{}
 
 	if q.Foo != "" {

--- a/dcim_related-connections.go
+++ b/dcim_related-connections.go
@@ -74,7 +74,7 @@ type relatedConnectionsOptions struct {
 	PeerInterface string
 }
 
-func (o *relatedConnectionsOptions) values() (url.Values, error) {
+func (o *relatedConnectionsOptions) Values() (url.Values, error) {
 	err := errors.New(
 		"must provide non-zero values for both peer-device and peer-interface",
 	)

--- a/dcim_related-connections_test.go
+++ b/dcim_related-connections_test.go
@@ -87,7 +87,7 @@ func TestGetRelatedConnectionWithOptions(t *testing.T) {
 	for i, test := range happyPathTests {
 		t.Logf("[%02d] happy path test %q", i, test.desc)
 
-		got, err := test.o.values()
+		got, err := test.o.Values()
 		if err != nil {
 			t.Fatalf("unexpected Values error: %v", err)
 		}
@@ -125,7 +125,7 @@ func TestGetRelatedConnectionWithOptions(t *testing.T) {
 	for i, test := range negativeTests {
 		t.Logf("[%02d] negative path test %q", i, test.desc)
 
-		if _, err := test.o.values(); err == nil {
+		if _, err := test.o.Values(); err == nil {
 			t.Fatal("expected Error but got nil")
 		}
 	}

--- a/ipam_aggregates.go
+++ b/ipam_aggregates.go
@@ -75,8 +75,8 @@ type ListAggregatesOptions struct {
 	DateAdded time.Time
 }
 
-// values generates a url.Values map from the data in ListAggregatesOptions.
-func (o *ListAggregatesOptions) values() (url.Values, error) {
+// Values generates a url.Values map from the data in ListAggregatesOptions.
+func (o *ListAggregatesOptions) Values() (url.Values, error) {
 	if o == nil {
 		return nil, nil
 	}

--- a/ipam_aggregates_test.go
+++ b/ipam_aggregates_test.go
@@ -155,7 +155,7 @@ func TestListAggregatesOptionsValues(t *testing.T) {
 	for i, tt := range tests {
 		t.Logf("[%02d] test %q", i, tt.desc)
 
-		v, err := tt.o.values()
+		v, err := tt.o.Values()
 		if err != nil {
 			t.Fatalf("unexpected Values error: %v", err)
 		}

--- a/ipam_ipaddresses.go
+++ b/ipam_ipaddresses.go
@@ -180,8 +180,8 @@ type ListIPAddressesOptions struct {
 	Query string
 }
 
-// values generates a url.Values map from the data in ListIPAddressesOptions.
-func (o *ListIPAddressesOptions) values() (url.Values, error) {
+// Values generates a url.Values map from the data in ListIPAddressesOptions.
+func (o *ListIPAddressesOptions) Values() (url.Values, error) {
 	if o == nil {
 		return nil, nil
 	}

--- a/ipam_ipaddresses_test.go
+++ b/ipam_ipaddresses_test.go
@@ -214,7 +214,7 @@ func TestListIPAddressesOptionsValues(t *testing.T) {
 	for i, tt := range tests {
 		t.Logf("[%02d] test %q", i, tt.desc)
 
-		v, err := tt.o.values()
+		v, err := tt.o.Values()
 		if err != nil {
 			t.Fatalf("unexpected Values error: %v", err)
 		}

--- a/ipam_prefixes.go
+++ b/ipam_prefixes.go
@@ -89,8 +89,8 @@ type ListPrefixesOptions struct {
 	Query string
 }
 
-// values generates a url.Values map from the data in ListPrefixesOptions.
-func (o *ListPrefixesOptions) values() (url.Values, error) {
+// Values generates a url.Values map from the data in ListPrefixesOptions.
+func (o *ListPrefixesOptions) Values() (url.Values, error) {
 	if o == nil {
 		return nil, nil
 	}

--- a/ipam_prefixes_test.go
+++ b/ipam_prefixes_test.go
@@ -302,7 +302,7 @@ func TestListPrefixesOptionsValues(t *testing.T) {
 	for i, tt := range tests {
 		t.Logf("[%02d] test %q", i, tt.desc)
 
-		v, err := tt.o.values()
+		v, err := tt.o.Values()
 		if err != nil {
 			t.Fatalf("unexpected Values error: %v", err)
 		}

--- a/ipam_vlans.go
+++ b/ipam_vlans.go
@@ -97,8 +97,8 @@ type ListVLANsOptions struct {
 	VID      VLANID
 }
 
-// values generates a url.Values map from the data in ListVLANsOptions.
-func (o *ListVLANsOptions) values() (url.Values, error) {
+// Values generates a url.Values map from the data in ListVLANsOptions.
+func (o *ListVLANsOptions) Values() (url.Values, error) {
 	if o == nil {
 		return nil, nil
 	}

--- a/ipam_vlans_test.go
+++ b/ipam_vlans_test.go
@@ -274,7 +274,7 @@ func TestListVLANsOptionsValues(t *testing.T) {
 	for i, tt := range tests {
 		t.Logf("[%02d] test %q", i, tt.desc)
 
-		v, err := tt.o.values()
+		v, err := tt.o.Values()
 		if err != nil {
 			t.Fatalf("unexpected Values error: %v", err)
 		}

--- a/netbox.go
+++ b/netbox.go
@@ -22,7 +22,7 @@ import "net/url"
 // Valuer implementations are used to generate request URL parameters
 // that NetBox can use to filter data.
 type Valuer interface {
-	values() (url.Values, error)
+	Values() (url.Values, error)
 }
 
 // A Family is an IP address family, used by NetBox to filter either IPv4


### PR DESCRIPTION
A slight oversight on my part.  Needs to happen to allow external callers to pass `Valuer` implementations.