### PR TITLE
Netbox requires `parent` even if it is null

### DIFF
--- a/netbox/dcim_inventory-items_test.go
+++ b/netbox/dcim_inventory-items_test.go
@@ -132,12 +132,12 @@ func TestInventoryItemMarshalJSON(t *testing.T) {
 		{
 			desc: "Inventory item without manufacturer",
 			data: testInventoryItem(1),
-			want: []byte(`{"id":1,"device":10001,"name":"Inventory Item 1","part_id":"Part ID 1","serial":"Serial 1","discovered":true}`),
+			want: []byte(`{"id":1,"device":10001,"parent":null,"name":"Inventory Item 1","part_id":"Part ID 1","serial":"Serial 1","discovered":true}`),
 		},
 		{
 			desc: "Inventory item with manufacturer",
 			data: testInventoryItemWithManufacturer(2),
-			want: []byte(`{"device":10002,"name":"Inventory Item 2","manufacturer":20002,"part_id":"Part ID 2","serial":"Serial 2","discovered":true}`),
+			want: []byte(`{"device":10002,"parent":null,"name":"Inventory Item 2","manufacturer":20002,"part_id":"Part ID 2","serial":"Serial 2","discovered":true}`),
 		},
 	}
 

--- a/netbox/dcim_inventory-items_types.go
+++ b/netbox/dcim_inventory-items_types.go
@@ -47,7 +47,7 @@ type NestedDevice struct {
 type InventoryItem struct {
 	ID           int                 `json:"id,omitempty"`
 	Device       NestedDevice        `json:"device"`
-	Parent       *int                `json:"parent,omitempty"`
+	Parent       *int                `json:"parent"`
 	Name         string              `json:"name"`
 	Manufacturer *NestedManufacturer `json:"manufacturer,omitempty"`
 	PartID       string              `json:"part_id,omitempty"`
@@ -61,7 +61,7 @@ type InventoryItem struct {
 type writableInventoryItem struct {
 	ID           int    `json:"id,omitempty"`
 	Device       int    `json:"device"`
-	Parent       *int   `json:"parent,omitempty"`
+	Parent       *int   `json:"parent"`
 	Name         string `json:"name"`
 	Manufacturer *int   `json:"manufacturer,omitempty"`
 	PartID       string `json:"part_id,omitempty"`


### PR DESCRIPTION
Once I had the tokens in place, I did a full test of inventory items and ran in to this bug.

I was tripped up for ten or fifteen minutes while forgetting that InventoryItem actually uses writableInventoryItem under the hood. Don't know of another way to handle it though.